### PR TITLE
Allow interpreters to target a specific bytecode version

### DIFF
--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/GroovyScriptInterpreter.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/GroovyScriptInterpreter.java
@@ -42,6 +42,8 @@ class GroovyScriptInterpreter implements ScriptInterpreter {
     private final RootLoader childFirstLoader =
             new RootLoader(new URL[] {}, Thread.currentThread().getContextClassLoader());
 
+    private String targetBytecode;
+
     @Override
     public void setClassPath(List<String> classPath) {
         if (classPath == null || classPath.isEmpty()) {
@@ -51,11 +53,37 @@ class GroovyScriptInterpreter implements ScriptInterpreter {
         classPath.stream().map(this::toUrl).forEach(childFirstLoader::addURL);
     }
 
+    @Override
+    public void setTargetBytecode(String version) {
+        this.targetBytecode = version;
+    }
+
     private URL toUrl(String path) {
         try {
             return new File(path).toURI().toURL();
         } catch (MalformedURLException e) {
             throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Maps a Maven-style release value (for example <code>"8"</code>) to the version string Groovy's
+     * {@link CompilerConfiguration#setTargetBytecode(String)} expects (for example <code>"1.8"</code>). Groovy uses
+     * the <code>"1.x"</code> form for JDK 4 through 8, and bare version numbers from JDK 9 onward.
+     *
+     * @param version The Maven-style release value, must not be <code>null</code>.
+     * @return The Groovy-compatible bytecode version string.
+     */
+    static String normalizeTargetBytecode(String version) {
+        switch (version) {
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "8":
+                return "1." + version;
+            default:
+                return version;
         }
     }
 
@@ -76,10 +104,13 @@ class GroovyScriptInterpreter implements ScriptInterpreter {
                 System.setOut(scriptOutput);
             }
 
-            GroovyShell interpreter = new GroovyShell(
-                    childFirstLoader,
-                    new Binding(globalVariables),
-                    new CompilerConfiguration(CompilerConfiguration.DEFAULT));
+            CompilerConfiguration compilerConfiguration = new CompilerConfiguration(CompilerConfiguration.DEFAULT);
+            if (targetBytecode != null) {
+                compilerConfiguration.setTargetBytecode(normalizeTargetBytecode(targetBytecode));
+            }
+
+            GroovyShell interpreter =
+                    new GroovyShell(childFirstLoader, new Binding(globalVariables), compilerConfiguration);
 
             Thread.currentThread().setContextClassLoader(childFirstLoader);
             return interpreter.evaluate(script);

--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/ScriptInterpreter.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/ScriptInterpreter.java
@@ -42,6 +42,16 @@ public interface ScriptInterpreter extends Closeable {
     void setClassPath(List<String> classPath);
 
     /**
+     * Sets the target bytecode version for interpreters that support bytecode-level compilation. Interpreters
+     * that do not compile to a specific bytecode level (for example BeanShell) may ignore this.
+     *
+     * @param version The target bytecode version, may be <code>null</code> to use the interpreter's own default.
+     */
+    default void setTargetBytecode(String version) {
+        // no-op by default
+    }
+
+    /**
      * Evaluates the specified script.
      *
      * @param script          The script contents to evaluate, must not be <code>null</code>.

--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/ScriptRunner.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/ScriptRunner.java
@@ -105,6 +105,18 @@ public class ScriptRunner implements Closeable {
     }
 
     /**
+     * Sets the target bytecode version for the hook scripts, for interpreters that support bytecode-level
+     * compilation.
+     *
+     * @param version The target bytecode version, may be <code>null</code> to use each interpreter's own default.
+     */
+    public void setTargetBytecode(String version) {
+        if (version != null) {
+            scriptInterpreters.values().forEach(scriptInterpreter -> scriptInterpreter.setTargetBytecode(version));
+        }
+    }
+
+    /**
      * Sets the file encoding of the hook scripts.
      *
      * @param encoding The file encoding of the hook scripts, may be <code>null</code> or empty to use the platform's

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/GroovyScriptInterpreterTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/GroovyScriptInterpreterTest.java
@@ -96,4 +96,24 @@ class GroovyScriptInterpreterTest {
         }
         assertEquals("data", out.toString());
     }
+
+    @Test
+    void evaluateScriptWithTargetBytecode() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ScriptInterpreter interpreter = new GroovyScriptInterpreter()) {
+            interpreter.setTargetBytecode("8");
+            assertEquals(
+                    Boolean.TRUE,
+                    interpreter.evaluateScript("print \"Test\"\nreturn true", null, new PrintStream(out)));
+        }
+        assertEquals("Test", out.toString());
+    }
+
+    @Test
+    void normalizeTargetBytecodeMapsOldJdksToDotForm() {
+        assertEquals("1.4", GroovyScriptInterpreter.normalizeTargetBytecode("4"));
+        assertEquals("1.8", GroovyScriptInterpreter.normalizeTargetBytecode("8"));
+        assertEquals("9", GroovyScriptInterpreter.normalizeTargetBytecode("9"));
+        assertEquals("17", GroovyScriptInterpreter.normalizeTargetBytecode("17"));
+    }
 }


### PR DESCRIPTION
## What / why

Groovy's `CompilerConfiguration` defaults its target bytecode to whatever JDK is currently
running it (`defaultTargetBytecode()` reads the running JVM's version), with no way to override
it. This means `verify.groovy` hook scripts get compiled to the executing JDK's bytecode level
regardless of the project's own `maven.compiler.release`, which breaks old source revisions as
the JDK running the build evolves. See apache/maven-invoker-plugin#742 for the full report.

This PR adds a `setTargetBytecode(String)` method through the interpreter stack:
- `ScriptInterpreter` gets a default no-op method (interpreters like BeanShell that don't compile
  to a bytecode level can ignore it).
- `GroovyScriptInterpreter` implements it, storing the value and applying it to the
  `CompilerConfiguration` used in `evaluateScript()`. A small `normalizeTargetBytecode` helper
  maps Maven-style release values (`"8"`) to the form Groovy's `setTargetBytecode` expects
  (`"1.8"` for JDK 4-8, bare numbers from JDK 9 on).
- `ScriptRunner` exposes the same setter, applying it to all registered interpreters.

This only adds the capability to `maven-script-interpreter`. Wiring `maven-invoker-plugin` to
read `maven.compiler.release` and call this new setter is a separate follow-up PR against that
repo, since it depends on this change being available.

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).
  (N/A — this repo has no `run-its` profile or integration-test suite.)

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an Apache Individual Contributor License Agreement.
