### PR TITLE
Fix FileLogger NPE when log file has no parent directory (#204)

### DIFF
--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
@@ -65,7 +65,10 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
 
         if (outputFile != null) {
             Path outputPath = outputFile.toPath();
-            Files.createDirectories(outputPath.getParent());
+            Path parent = outputPath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
             outputStream = createOutputStream(outputPath);
         } else {
             outputStream = new NullOutputStream();

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
@@ -109,4 +109,24 @@ public class FileLoggerTest {
         assertTrue(outputFile.exists());
         assertEquals(EXPECTED_LOG, new String(Files.readAllBytes(outputFile.toPath())));
     }
+
+    @Test
+    void bareFilenameNoParent() throws Exception {
+        File outputFile = new File("filelogger-204-bare.log");
+        assertNull(outputFile.getParent());
+        try {
+            try (FileLogger fileLogger = new FileLogger(outputFile)) {
+                fileLogger.consumeLine("Test1");
+                fileLogger.getPrintStream().println("Test2");
+                fileLogger.getPrintStream().flush();
+
+                assertEquals(outputFile, fileLogger.getOutputFile());
+            }
+
+            assertTrue(outputFile.exists());
+            assertEquals(EXPECTED_LOG, new String(Files.readAllBytes(outputFile.toPath())));
+        } finally {
+            Files.deleteIfExists(outputFile.toPath());
+        }
+    }
 }


### PR DESCRIPTION
Fixes #204.

`FileLogger` called `Files.createDirectories(outputPath.getParent())` even when `getParent()` was null (bare filename like `new File("build.log")`), which NPE'd. I only create the parent directories when a parent path exists, and added a unit test for the bare-filename case.