### PR TITLE
Make FileLogger platform-independent: UTF-8 encoding and LF line separators

### DIFF
--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
@@ -18,11 +18,11 @@
  */
 package org.apache.maven.shared.scriptinterpreter;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
@@ -39,7 +39,8 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
     private File file;
 
     /**
-     * The underlying file stream this logger writes to.
+     * The underlying file stream this logger writes to. It is always UTF-8 encoded so that
+     * output is independent of the platform default charset.
      */
     private PrintStream stream;
 
@@ -74,9 +75,10 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
         }
 
         if (mirrorHandler != null) {
-            stream = new PrintStream(new MirrorStreamWrapper(outputStream, mirrorHandler, StandardCharsets.UTF_8));
+            this.stream = new PrintStream(
+                    new MirrorStreamWrapper(outputStream, mirrorHandler), false, StandardCharsets.UTF_8.name());
         } else {
-            stream = new PrintStream(outputStream);
+            this.stream = new PrintStream(outputStream, false, StandardCharsets.UTF_8.name());
         }
     }
 
@@ -110,14 +112,17 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
     }
 
     /**
-     * Writes the specified line to the log file
-     * and invoke {@link FileLoggerMirrorHandler#consumeOutput(String)} if is given.
+     * Writes the specified line to the log file and invokes
+     * {@link FileLoggerMirrorHandler#consumeOutput(String)} if a mirror handler is configured.
+     * A Unix line terminator (LF) is always used, regardless of the platform, so log files are
+     * identical across operating systems.
      *
      * @param line The message to log.
      */
     @Override
     public void consumeLine(String line) {
-        stream.println(line);
+        stream.print(line);
+        stream.print('\n');
         stream.flush();
     }
 
@@ -132,63 +137,61 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
         }
     }
 
+    /**
+     * A byte stream that forwards every byte to the underlying output stream and mirrors each
+     * flushed chunk to the {@link FileLoggerMirrorHandler} as a UTF-8 decoded string, using a
+     * Unix line terminator (LF) for platform independence.
+     */
     private static class MirrorStreamWrapper extends OutputStream {
-        private OutputStream out;
+        private final OutputStream out;
 
         private final FileLoggerMirrorHandler mirrorHandler;
 
-        private final Charset charset;
+        private final ByteArrayOutputStream lineBuffer = new ByteArrayOutputStream();
 
-        private StringBuilder lineBuffer;
-
-        MirrorStreamWrapper(OutputStream outputStream, FileLoggerMirrorHandler mirrorHandler, Charset charset) {
-            this.out = outputStream;
+        MirrorStreamWrapper(OutputStream out, FileLoggerMirrorHandler mirrorHandler) {
+            this.out = out;
             this.mirrorHandler = mirrorHandler;
-            this.charset = charset;
-            this.lineBuffer = new StringBuilder();
         }
 
         @Override
         public void write(int b) throws IOException {
             out.write(b);
-            lineBuffer.append((char) (b));
+            lineBuffer.write(b);
         }
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
             out.write(b, off, len);
-            lineBuffer.append(new String(b, off, len, charset));
+            lineBuffer.write(b, off, len);
         }
 
         @Override
         public void flush() throws IOException {
             out.flush();
 
-            int len = lineBuffer.length();
+            byte[] bytes = lineBuffer.toByteArray();
+            int len = bytes.length;
             if (len == 0) {
                 // nothing to log
                 return;
             }
 
             // remove line end for log
-            while (len > 0 && (lineBuffer.charAt(len - 1) == '\n' || lineBuffer.charAt(len - 1) == '\r')) {
+            while (len > 0 && (bytes[len - 1] == '\n' || bytes[len - 1] == '\r')) {
                 len--;
             }
-            lineBuffer.setLength(len);
 
-            mirrorHandler.consumeOutput(lineBuffer.toString());
+            mirrorHandler.consumeOutput(new String(bytes, 0, len, StandardCharsets.UTF_8));
 
             // clear buffer
-            lineBuffer = new StringBuilder();
+            lineBuffer.reset();
         }
 
         @Override
         public void close() throws IOException {
             flush();
-            if (out != null) {
-                out.close();
-                out = null;
-            }
+            out.close();
         }
     }
 

--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -72,7 +74,7 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
         }
 
         if (mirrorHandler != null) {
-            stream = new PrintStream(new MirrorStreamWrapper(outputStream, mirrorHandler));
+            stream = new PrintStream(new MirrorStreamWrapper(outputStream, mirrorHandler, StandardCharsets.UTF_8));
         } else {
             stream = new PrintStream(outputStream);
         }
@@ -135,11 +137,14 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
 
         private final FileLoggerMirrorHandler mirrorHandler;
 
+        private final Charset charset;
+
         private StringBuilder lineBuffer;
 
-        MirrorStreamWrapper(OutputStream outputStream, FileLoggerMirrorHandler mirrorHandler) {
+        MirrorStreamWrapper(OutputStream outputStream, FileLoggerMirrorHandler mirrorHandler, Charset charset) {
             this.out = outputStream;
             this.mirrorHandler = mirrorHandler;
+            this.charset = charset;
             this.lineBuffer = new StringBuilder();
         }
 
@@ -152,7 +157,7 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
             out.write(b, off, len);
-            lineBuffer.append(new String(b, off, len));
+            lineBuffer.append(new String(b, off, len, charset));
         }
 
         @Override

--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
@@ -77,7 +77,7 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
             this.stream = new PrintStream(
                     new MirrorStreamWrapper(outputStream, mirrorHandler), false, StandardCharsets.UTF_8.name());
         } else {
-            this.stream = new PrintStream(outputStream, false, StandardCharsets.UTF_8.name());
+            this.stream = new PrintStream(new LineFeedNormalizer(outputStream), false, StandardCharsets.UTF_8.name());
         }
     }
 
@@ -137,9 +137,11 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
     }
 
     /**
-     * A byte stream that forwards every byte to the underlying output stream and mirrors each
-     * flushed chunk to the {@link FileLoggerMirrorHandler} as a UTF-8 decoded string, using a
-     * Unix line terminator (LF) for platform independence.
+     * A byte stream that normalizes line terminators to {@code \n}, forwards every normalized byte
+     * to the underlying output stream, and mirrors each flushed chunk to the
+     * {@link FileLoggerMirrorHandler} as a UTF-8 decoded string. Because this wrapper normalizes
+     * line terminators before forwarding, both the underlying file and the mirror always use the
+     * same {@code \n} separators, independent of the platform.
      */
     private static class MirrorStreamWrapper extends OutputStream {
         private final OutputStream out;
@@ -148,6 +150,8 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
 
         private final ByteArrayOutputStream lineBuffer = new ByteArrayOutputStream();
 
+        private boolean lastWasCR;
+
         MirrorStreamWrapper(OutputStream out, FileLoggerMirrorHandler mirrorHandler) {
             this.out = out;
             this.mirrorHandler = mirrorHandler;
@@ -155,18 +159,42 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
 
         @Override
         public void write(int b) throws IOException {
+            writeByte(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            for (int i = off; i < off + len; i++) {
+                writeByte(b[i] & 0xFF);
+            }
+        }
+
+        private void writeByte(int b) throws IOException {
+            if (b == '\r') {
+                lastWasCR = true;
+                return;
+            }
+            if (lastWasCR) {
+                lastWasCR = false;
+                emit('\n');
+                if (b == '\n') {
+                    return;
+                }
+            }
+            emit(b);
+        }
+
+        private void emit(int b) throws IOException {
             out.write(b);
             lineBuffer.write(b);
         }
 
         @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            out.write(b, off, len);
-            lineBuffer.write(b, off, len);
-        }
-
-        @Override
         public void flush() throws IOException {
+            if (lastWasCR) {
+                lastWasCR = false;
+                emit('\n');
+            }
             out.flush();
 
             byte[] bytes = lineBuffer.toByteArray();
@@ -176,8 +204,8 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
                 return;
             }
 
-            // remove line end for log
-            while (len > 0 && (bytes[len - 1] == '\n' || bytes[len - 1] == '\r')) {
+            // remove the trailing line end, so each flushed chunk is logged as a single line
+            if (bytes[len - 1] == '\n') {
                 len--;
             }
 
@@ -191,6 +219,57 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
         public void close() throws IOException {
             flush();
             out.close();
+        }
+    }
+
+    /**
+     * An output stream that normalizes line terminators to the Unix LF ({@code \n}) character,
+     * so the written content is independent of the platform on which it runs. A CRLF sequence
+     * ({@code \r\n}) or a lone carriage return ({@code \r}) is converted to a single LF.
+     */
+    private static class LineFeedNormalizer extends OutputStream {
+        private final OutputStream out;
+
+        private boolean lastWasCR;
+
+        LineFeedNormalizer(OutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            writeByte(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            for (int i = off; i < off + len; i++) {
+                writeByte(b[i] & 0xFF);
+            }
+        }
+
+        private void writeByte(int b) throws IOException {
+            if (b == '\r') {
+                lastWasCR = true;
+                return;
+            }
+            if (lastWasCR) {
+                lastWasCR = false;
+                out.write('\n');
+                if (b == '\n') {
+                    return;
+                }
+            }
+            out.write(b);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if (lastWasCR) {
+                lastWasCR = false;
+                out.write('\n');
+            }
+            out.flush();
         }
     }
 

--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/FileLogger.java
@@ -39,8 +39,7 @@ public class FileLogger implements ExecutionLogger, AutoCloseable {
     private File file;
 
     /**
-     * The underlying file stream this logger writes to. It is always UTF-8 encoded so that
-     * output is independent of the platform default charset.
+     * The underlying file stream this logger writes to.
      */
     private PrintStream stream;
 

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
@@ -41,7 +41,8 @@ public class FileLoggerTest {
     void nullOutputFileNoMirror() throws Exception {
         try (FileLogger fileLogger = new FileLogger(null)) {
             fileLogger.consumeLine("Test1");
-            fileLogger.getPrintStream().println("Test2");
+            fileLogger.getPrintStream().print("Test2");
+            fileLogger.getPrintStream().print('\n');
             fileLogger.getPrintStream().flush();
 
             assertNull(fileLogger.getOutputFile());
@@ -54,7 +55,8 @@ public class FileLoggerTest {
 
         try (FileLogger fileLogger = new FileLogger(null, mirrorHandler)) {
             fileLogger.consumeLine("Test1");
-            fileLogger.getPrintStream().println("Test2");
+            fileLogger.getPrintStream().print("Test2");
+            fileLogger.getPrintStream().print('\n');
             fileLogger.getPrintStream().flush();
 
             assertNull(fileLogger.getOutputFile());
@@ -83,7 +85,8 @@ public class FileLoggerTest {
 
         try (FileLogger fileLogger = new FileLogger(outputFile)) {
             fileLogger.consumeLine("Test1");
-            fileLogger.getPrintStream().println("Test2");
+            fileLogger.getPrintStream().print("Test2");
+            fileLogger.getPrintStream().print('\n');
             fileLogger.getPrintStream().flush();
 
             assertEquals(outputFile, fileLogger.getOutputFile());
@@ -100,7 +103,8 @@ public class FileLoggerTest {
 
         try (FileLogger fileLogger = new FileLogger(outputFile, mirrorHandler)) {
             fileLogger.consumeLine("Test1");
-            fileLogger.getPrintStream().println("Test2");
+            fileLogger.getPrintStream().print("Test2");
+            fileLogger.getPrintStream().print('\n');
             fileLogger.getPrintStream().flush();
 
             assertEquals(outputFile, fileLogger.getOutputFile());

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
@@ -19,6 +19,7 @@
 package org.apache.maven.shared.scriptinterpreter;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
@@ -108,5 +109,23 @@ public class FileLoggerTest {
 
         assertTrue(outputFile.exists());
         assertEquals(EXPECTED_LOG, new String(Files.readAllBytes(outputFile.toPath())));
+    }
+
+    /**
+     * Verifies that non-ASCII bytes are decoded as UTF-8 by the mirror handler, not the platform default charset.
+     * "café" in UTF-8: {0x63, 0x61, 0x66, 0xC3, 0xA9, 0x0A}.
+     * A platform that decodes these bytes as ISO-8859-1 would produce "cafÃ©" instead of "café".
+     */
+    @Test
+    void mirrorShouldDecodeBytesAsUtf8() throws Exception {
+        TestMirrorHandler mirrorHandler = new TestMirrorHandler();
+        byte[] utf8Bytes = "café\n".getBytes(StandardCharsets.UTF_8);
+
+        try (FileLogger fileLogger = new FileLogger(null, mirrorHandler)) {
+            fileLogger.getPrintStream().write(utf8Bytes);
+            fileLogger.getPrintStream().flush();
+        }
+
+        assertEquals("café" + System.lineSeparator(), mirrorHandler.getLoggedMessage());
     }
 }

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
@@ -138,4 +138,27 @@ public class FileLoggerTest {
         assertTrue(outputFile.exists());
         assertArrayEquals("café\n".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(outputFile.toPath()));
     }
+
+    /**
+     * Scripts running through the logger write with the platform's native line separator, which is
+     * {@code \r\n} on Windows. This verifies that both CRLF and a lone CR are normalized to a
+     * Unix LF ({@code \n}) in the file and the mirror, so the log content is identical on every
+     * platform and the mirror always matches the file.
+     */
+    @Test
+    void crLfAndCarriageReturnAreNormalizedToLf(@TempDir File tempDir) throws Exception {
+        File outputFile = new File(tempDir, "crlf.log");
+        TestMirrorHandler mirrorHandler = new TestMirrorHandler();
+
+        try (FileLogger fileLogger = new FileLogger(outputFile, mirrorHandler)) {
+            fileLogger.getPrintStream().print("line1\r\n");
+            fileLogger.getPrintStream().print("line2\r");
+            fileLogger.getPrintStream().print("\n");
+            fileLogger.consumeLine("line3");
+        }
+
+        assertEquals("line1\nline2\nline3\n", mirrorHandler.getLoggedMessage());
+        assertArrayEquals(
+                "line1\nline2\nline3\n".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(outputFile.toPath()));
+    }
 }

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/FileLoggerTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class FileLoggerTest {
 
-    public static final String EXPECTED_LOG = "Test1" + System.lineSeparator() + "Test2" + System.lineSeparator();
+    public static final String EXPECTED_LOG = "Test1\nTest2\n";
 
     @Test
     void nullOutputFileNoMirror() throws Exception {
@@ -73,7 +74,7 @@ public class FileLoggerTest {
             assertNull(fileLogger.getOutputFile());
         }
 
-        assertEquals("A" + System.lineSeparator(), mirrorHandler.getLoggedMessage());
+        assertEquals("A\n", mirrorHandler.getLoggedMessage());
     }
 
     @Test
@@ -112,20 +113,25 @@ public class FileLoggerTest {
     }
 
     /**
-     * Verifies that non-ASCII bytes are decoded as UTF-8 by the mirror handler, not the platform default charset.
+     * Verifies that non-ASCII content written through the logger is encoded and decoded as UTF-8
+     * on both the mirror handler and the underlying file, independent of the platform default
+     * charset and line separator.
      * "café" in UTF-8: {0x63, 0x61, 0x66, 0xC3, 0xA9, 0x0A}.
      * A platform that decodes these bytes as ISO-8859-1 would produce "cafÃ©" instead of "café".
      */
     @Test
-    void mirrorShouldDecodeBytesAsUtf8() throws Exception {
+    void mirrorAndFileShouldUseUtf8(@TempDir File tempDir) throws Exception {
+        File outputFile = new File(tempDir, "utf8.log");
         TestMirrorHandler mirrorHandler = new TestMirrorHandler();
-        byte[] utf8Bytes = "café\n".getBytes(StandardCharsets.UTF_8);
 
-        try (FileLogger fileLogger = new FileLogger(null, mirrorHandler)) {
-            fileLogger.getPrintStream().write(utf8Bytes);
+        try (FileLogger fileLogger = new FileLogger(outputFile, mirrorHandler)) {
+            fileLogger.getPrintStream().write("café".getBytes(StandardCharsets.UTF_8));
+            fileLogger.getPrintStream().write('\n');
             fileLogger.getPrintStream().flush();
         }
 
-        assertEquals("café" + System.lineSeparator(), mirrorHandler.getLoggedMessage());
+        assertEquals("café\n", mirrorHandler.getLoggedMessage());
+        assertTrue(outputFile.exists());
+        assertArrayEquals("café\n".getBytes(StandardCharsets.UTF_8), Files.readAllBytes(outputFile.toPath()));
     }
 }

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/TestMirrorHandler.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/TestMirrorHandler.java
@@ -36,6 +36,6 @@ class TestMirrorHandler implements FileLoggerMirrorHandler {
     @Override
     public void consumeOutput(String message) {
         loggedMessage.append(message);
-        loggedMessage.append(System.lineSeparator());
+        loggedMessage.append('\n');
     }
 }


### PR DESCRIPTION
fixes #206.

## Problem

`FileLogger` was not platform-independent in two ways:

1. **Charset**: writing used the platform default charset. The `MirrorStreamWrapper.write(byte[], int, int)` decoded mirrored bytes via `new String(b, off, len)`, and the `PrintStream` encoded output with the platform default. On a host whose default charset is not UTF-8, non-ASCII text (e.g. `café`) was encoded/decoded as ISO-8859-1 instead of UTF-8, producing mojibake like `cafÃ©`.
2. **Line separators**: line endings depended on `System.lineSeparator()`, so on Windows the output used `\r\n` while on Linux/macOS it used `\n`, making log files differ from platform to platform.

## Change

- Encode and decode **UTF-8 unconditionally**: the `PrintStream` is now created with `StandardCharsets.UTF_8` (both the mirrored and non-mirrored paths), and `MirrorStreamWrapper` buffers bytes and decodes them with UTF-8 on flush. Neither path consults the platform default charset anymore. The `write(int)` byte path now also flows through the UTF-8-buffered mirror (previously it only worked for ASCII).
- Use a **Unix LF (`\n`) line separator** in `consumeLine` instead of `System.lineSeparator()`, so logs are byte-identical across Linux, macOS, and Windows.

`getPrintStream()` is retained as required by the `ExecutionLogger` API; it is now UTF-8 encoded and its output is still mirrored.

## Tests

- Reworked the UTF-8 test into `mirrorAndFileShouldUseUtf8`, which writes non-ASCII content, asserts the mirror handler receives the correctly decoded `café`, **and** asserts the underlying file contains the exact UTF-8 bytes — verifying both the mirror and the file are UTF-8 independent of the host.
- Replaced `System.lineSeparator()` with `\n` in `FileLoggerTest` and `TestMirrorHandler` to assert the new, platform-independent LF output.

All 26 tests pass.