### PR TITLE
Use UTF-8 for script decoding instead of platform default charset

### DIFF
--- a/src/main/java/org/apache/maven/shared/scriptinterpreter/ScriptRunner.java
+++ b/src/main/java/org/apache/maven/shared/scriptinterpreter/ScriptRunner.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -56,7 +57,7 @@ public class ScriptRunner implements Closeable {
     private final Map<String, Object> globalVariables;
 
     /**
-     * The file encoding of the hook scripts or <code>null</code> to use platform encoding.
+     * The file encoding of the hook scripts or <code>null</code> to use UTF-8.
      */
     private String encoding;
 
@@ -119,8 +120,7 @@ public class ScriptRunner implements Closeable {
     /**
      * Sets the file encoding of the hook scripts.
      *
-     * @param encoding The file encoding of the hook scripts, may be <code>null</code> or empty to use the platform's
-     *                 default encoding.
+     * @param encoding The file encoding of the hook scripts, may be <code>null</code> or empty to use UTF-8.
      */
     public void setScriptEncoding(String encoding) {
         this.encoding = encoding != null && !encoding.isEmpty() ? encoding : null;
@@ -202,7 +202,7 @@ public class ScriptRunner implements Closeable {
             if (encoding != null) {
                 script = new String(bytes, encoding);
             } else {
-                script = new String(bytes);
+                script = new String(bytes, StandardCharsets.UTF_8);
             }
         } catch (IOException e) {
             String errorMessage =

--- a/src/test/java/org/apache/maven/shared/scriptinterpreter/ScriptRunnerTest.java
+++ b/src/test/java/org/apache/maven/shared/scriptinterpreter/ScriptRunnerTest.java
@@ -264,6 +264,31 @@ class ScriptRunnerTest {
         assertTrue(logContent.contains("wireMockServer stopped"));
     }
 
+    /**
+     * Verifies that a Groovy script containing non-ASCII characters (UTF-8 encoded)
+     * is decoded correctly when no explicit encoding is set. The script file
+     * utf8-test.groovy contains the UTF-8 string literal "café" and asserts it
+     * matches the expected value, returning true on success.
+     *
+     * @see <a href="https://github.com/apache/maven-script-interpreter/issues/206">#206</a>
+     */
+    @Test
+    void groovyUtf8ScriptShouldDecodeCorrectly() throws Exception {
+        File logFile = new File(tempDir, "build.log");
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("expected", "café");
+
+        try (FileLogger logger = new FileLogger(logFile);
+                ScriptRunner scriptRunner = new ScriptRunner()) {
+            scriptRunner.run("utf8-test", new File("src/test/resources/groovy-test/utf8-test.groovy"), context, logger);
+        }
+
+        String logContent = new String(Files.readAllBytes(logFile.toPath()));
+        assertTrue(logContent.contains("expected=café"));
+        assertTrue(logContent.contains("actual=café"));
+    }
+
     private Map<String, ?> buildContext() {
         Map<String, Object> context = new HashMap<>();
         context.put("foo", "bar");

--- a/src/test/resources/groovy-test/utf8-test.groovy
+++ b/src/test/resources/groovy-test/utf8-test.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def result = context.get("expected")
+assert result != null
+System.out.println("expected=" + result)
+
+def actual = "café"
+System.out.println("actual=" + actual)
+
+return result.equals(actual)


### PR DESCRIPTION
Partially fixes #206.

`ScriptRunner.executeRun` falls back to `new String(bytes)` (platform default charset) when no explicit encoding is set (ScriptRunner.java:205). This makes script content decoding host-dependent.

Scripts being run are likely to come from source code control systems, and are not necessarily authored on the system they're running on. In 2026 UTF-8 is the best guess when no encoding is specified. In particular in practice this is by far the most common encoding for Groovy scripts. 

This change replaces `new String(bytes)` with `new String(bytes, StandardCharsets.UTF_8)` so the fallback decoding is always UTF-8. The `setScriptEncoding` javadoc is updated to document the new default.

Includes a Groovy test script (`utf8-test.groovy`) containing the non-ASCII string literal "café" and a test (`groovyUtf8ScriptShouldDecodeCorrectly`) that runs it via `ScriptRunner` and verifies the decoded output is correct.